### PR TITLE
Allow custom dictionary to be passed as an option

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -7,7 +7,7 @@ var generator = function() {
 	  , paragraphLowerBound = options.paragraphLowerBound || 3
 	  , paragraphUpperBound = options.paragraphUpperBound || 7
 	  , format = options.format || 'plain'
-    , words = require('./dictionary').words
+    , words = options.words || require('./dictionary').words
     , random = options.random || Math.random;
 
   units = simplePluralize(units.toLowerCase());

--- a/readme.markdown
+++ b/readme.markdown
@@ -47,6 +47,7 @@ output = loremIpsum({
   , paragraphLowerBound: 3        // Minimum sentences per paragraph.
   , paragraphUpperBound: 7        // Maximum sentences per paragraph.
   , format: 'plain'               // Plain text or html
+  , words: ['ad', 'dolor', ... ]  // Custom word dictionary. Uses dictionary.words (in lib/dictionary.js) by default.
   , random: Math.random           // A PRNG function. Uses Math.random by default
 });
 ```


### PR DESCRIPTION
I've tweaked the code to allow the user to provide a custom word dictionary, instead of just using traditional Lorem Ipsum. Is this a feature you'd be interested in merging?

Here is an example:

``` js
var loremIpsum = require('lorem-ipsum');

var digits = ['one', 'two', 'three', 'four' /* and so on... */];
var hipsterIpsum = ['echo', 'park', 'salvia', 'vhs' /* and so on... */];

console.log(loremIpsum());
// Returns "Anim enim est cupidatat fugiat laborum ea ut laboris consequat proident."

console.log(loremIpsum({words: digits}));
// Returns "Ten two eight six six ten ten eight ten seven three."

console.log(loremIpsum({words: hipsterIpsum}));
// Returns "Trade pork selvage actually belly salvia ethnic vinegar craft pop-up stumptown butcher."


// Credit: Hipster Ipsum taken from http://hipsteripsum.me/.
```

Note: I didn't update CLI usage with the same functionality - currently my use case is as a Node module... though I can take a look at updating CLI code too if you wish.
