### PR TITLE
Add missing variable declaration

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -58,7 +58,9 @@ var generator = function() {
   var iter = 0
     , bounds = {min: 0, max: count}
     , string = ''
-    , prefix = '';
+    , prefix = ''
+    , openingTag
+    , closingTag;
 
   if (format == 'html') {
     openingTag = '<p>';


### PR DESCRIPTION
This removes an Exception `ReferenceError: openingTag is not defined` when run in `strict mode`.