### PR TITLE
add nodeunit devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "optimist": "~0.3.5"
   },
   "devDependencies": {
-    "alea": "0.0.9"
+    "alea": "0.0.9",
+    "nodeunit": "^0.11.0"
   },
   "optionalDependencies": {},
   "bin": {


### PR DESCRIPTION
running `npm test` causes the following error:

```
nodeunit: command not found
```

I've added [`nodeunit`](https://www.npmjs.com/package/nodeunit) as devDependency so the test script will always run, even if `nodeunit` is not installed globally on the system.