### PR TITLE
Replace depreciated optimist by minimist

### DIFF
--- a/bin/lorem-ipsum.bin.js
+++ b/bin/lorem-ipsum.bin.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-var optimist   = require('optimist')
+var minimist   = require('minimist')
   , generator  = require('./../lib/generator')
   , clipper    = require('./../lib/clipper');
 
 var options    = {}
-  , arguments  = optimist.argv
+  , arguments  = minimist(process.argv.slice(2))
   , loremIpsum = '';
 
 // Allow CLI user to run command with plain english. E.g. "lorem-ipsum 1 sentence" or "lorem-ipsum 3 words --copy"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT/X11",
   "main": "./lib/generator",
   "dependencies": {
-    "optimist": "~0.3.5"
+    "minimist": "~1.2.0"
   },
   "devDependencies": {
     "alea": "0.0.9",


### PR DESCRIPTION
README of optimist is clear: the module is depreciated and should be replaced by yargs or minimist

See: https://www.npmjs.com/package/optimist