### PR TITLE
Update license

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.4",
   "description": "Generates passages of lorem ipsum text suitable for use as placeholder copy in web pages, graphics, and more. Works in the browser, NodeJS, and React Native.",
   "author": "Nickolas Kenyeres <nkenyeres@gmail.com> (http://knicklabs.github.com)",
-  "license": "MIT/X11",
+  "license": "MIT",
   "main": "./lib/generator",
   "dependencies": {
     "minimist": "~1.2.0"


### PR DESCRIPTION
The license is still MIT, but the field was updated to be a proper SPDX code. Making this change resolves a warning that was previously shown on `npm install`.