### PR TITLE
lorem-ipsum.js must not depend on 'os'

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -14,9 +14,10 @@ function generator() {
   if (!suffix) {
     var isNode = typeof module !== 'undefined' && module.exports;
     var isReactNative = typeof product !== 'undefined' && product.navigator === 'ReactNative';
+    var isWindows = typeof process !== 'undefined' && 'win32' === process.platform;
 
-    if (!isReactNative && isNode) {
-      suffix = require('os').EOL;
+    if (!isReactNative && isNode && isWindows) {
+      suffix = '\r\n';
     } else {
       suffix = '\n';
     }


### PR DESCRIPTION
This PR is a suggestion to fix #25.

@knicklabs The change should not impact the behaviour.

I tested it on a Windows 7 64 bits running node and got \r\n as expected.

I also confirmed manually that the fix would fix the failure to build an iife module depending on lorem-ipsum.js with rollup. If you are interested into adding such iife build test, I can issue another PR for this purpose.