### PR TITLE
Remove seed option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4373,7 +4373,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -6434,7 +6434,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "0.5.1",
@@ -6800,7 +6801,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -8529,7 +8530,7 @@
       "dependencies": {
         "got": {
           "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
@@ -8928,14 +8929,6 @@
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
-    "random-seed": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/random-seed/-/random-seed-0.3.0.tgz",
-      "integrity": "sha1-2UXy4fOPSejViRNDG4v2u5N1Vs0=",
-      "requires": {
-        "json-stringify-safe": "^5.0.1"
-      }
-    },
     "randombytes": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
@@ -8969,7 +8962,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -9629,7 +9622,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -10893,7 +10886,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "webpack-cli": "^3.1.0"
   },
   "dependencies": {
-    "commander": "^2.17.1",
-    "random-seed": "^0.3.0"
+    "commander": "^2.17.1"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/src/lib/LoremIpsum.test.ts
+++ b/src/lib/LoremIpsum.test.ts
@@ -6,7 +6,6 @@ import LoremIpsum from "./LoremIpsum";
 
 describe("LoremIpsum", () => {
   const process = new ProcessHelper();
-  const seed = "xyz789";
 
   afterEach(() => process.resetPlatform());
 
@@ -102,7 +101,6 @@ describe("LoremIpsum", () => {
       const max = 5;
       const min = 3;
       const lorem = new LoremIpsum({
-        seed,
         wordsPerSentence: { max, min },
       });
       for (let i = 0; i < 100; i++) {
@@ -126,7 +124,6 @@ describe("LoremIpsum", () => {
       const max = 19;
       const min = 16;
       const lorem = new LoremIpsum({
-        seed,
         sentencesPerParagraph: { max, min },
       });
       for (let i = 0; i < 100; i++) {

--- a/src/lib/generator.test.ts
+++ b/src/lib/generator.test.ts
@@ -2,10 +2,9 @@ import Generator from "./generator";
 
 describe("generator", () => {
   let generator: Generator;
-  const seed = "ABC123";
 
   beforeEach(() => {
-    generator = new Generator({ seed });
+    generator = new Generator();
   });
 
   test("Should throw an error if instantiated with non-sensical paragraph bounds", () => {
@@ -45,24 +44,6 @@ describe("generator", () => {
     expect(generator.random).toEqual(random);
   });
 
-  test("Should use a seeded generator", () => {
-    let random = generator.random;
-    const instance1 = {
-      firstResult: random(),
-      secondResult: random(),
-    };
-
-    generator = new Generator({ seed });
-    random = generator.random;
-    const instance2 = {
-      firstResult: random(),
-      secondResult: random(),
-    };
-
-    expect(instance1.firstResult).toEqual(instance2.firstResult);
-    expect(instance1.secondResult).toEqual(instance2.secondResult);
-  });
-
   describe("generateRandomInteger", () => {
     test("Should generate an exact number given an equal min and max", () => {
       expect(generator.generateRandomInteger(7, 7)).toEqual(7);
@@ -89,7 +70,6 @@ describe("generator", () => {
       const min = 2;
       const max = 4;
       generator = new Generator({
-        seed,
         wordsPerSentence: { max, min },
       });
       for (let i = 0; i < 100; i++) {
@@ -116,7 +96,6 @@ describe("generator", () => {
       const min = 3;
       const max = 5;
       generator = new Generator({
-        seed,
         wordsPerSentence: { max, min },
       });
       for (let i = 0; i < 100; i++) {
@@ -138,7 +117,6 @@ describe("generator", () => {
       const min = 14;
       const max = 16;
       generator = new Generator({
-        seed,
         sentencesPerParagraph: { max, min },
       });
       for (let i = 0; i < 100; i++) {

--- a/src/lib/generator.ts
+++ b/src/lib/generator.ts
@@ -1,4 +1,3 @@
-import randomSeed from "random-seed";
 import { WORDS } from "../constants/words";
 import { capitalize, makeArrayOfLength } from "../util";
 
@@ -60,8 +59,6 @@ class Generator {
 
     if (random) {
       this.random = random;
-    } else if (seed) {
-      this.random = randomSeed.create(seed).random;
     } else {
       this.random = Math.random;
     }


### PR DESCRIPTION
This library had an undocumented `seed` option which would allow the user to supply a seed value that would result in a seeded PRNG function being used instead of `Math.random`. This allowed for reproducible results, which may be useful for some applications, such as for template generation.

As mentioned in #30, the package size increased dramatically between version 1 and 2. This was attributable to this undocumented feature. I am removing this option and subsequently removing the `random-seed` package. 

If a user wants reproducible results, they should supply their own seeded PRNG function via the `random` option. This has been the recommended method of accomplishing this since version 1.0.0.

I think this is an important change to keep the package size as small as possible.